### PR TITLE
Bump httpclient from 4.5.2 to 4.5.13 (#154)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
 			<dependency>
 			    <groupId>org.apache.httpcomponents</groupId>
 			    <artifactId>httpclient</artifactId>
-			    <version>4.5.2</version>
+			    <version>4.5.13</version>
 			    <scope>compile</scope>
 			    <exclusions>
                     <exclusion>


### PR DESCRIPTION
Bumps httpclient from 4.5.2 to 4.5.13.

---
updated-dependencies:
- dependency-name: org.apache.httpcomponents:httpclient
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>